### PR TITLE
Make project compilable with latest PlatformIO and STM32 platform 11

### DIFF
--- a/firmware/S42BV1.0/Close_loop/src/Libraries/cmsis/core_cmFunc.h
+++ b/firmware/S42BV1.0/Close_loop/src/Libraries/cmsis/core_cmFunc.h
@@ -1,0 +1,87 @@
+/**************************************************************************//**
+ * @file     core_cmFunc.h
+ * @brief    CMSIS Cortex-M Core Function Access Header File
+ * @version  V4.30
+ * @date     20. October 2015
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2015 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if   defined ( __ICCARM__ )
+ #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CORE_CMFUNC_H
+#define __CORE_CMFUNC_H
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+*/
+
+/*------------------ RealView Compiler -----------------*/
+#if   defined ( __CC_ARM )
+  #include "cmsis_armcc.h"
+
+/*------------------ ARM Compiler V6 -------------------*/
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #include "cmsis_armcc_V6.h"
+
+/*------------------ GNU Compiler ----------------------*/
+#elif defined ( __GNUC__ )
+  #include "cmsis_gcc.h"
+
+/*------------------ ICC Compiler ----------------------*/
+#elif defined ( __ICCARM__ )
+  #include <cmsis_iar.h>
+
+/*------------------ TI CCS Compiler -------------------*/
+#elif defined ( __TMS470__ )
+  #include <cmsis_ccs.h>
+
+/*------------------ TASKING Compiler ------------------*/
+#elif defined ( __TASKING__ )
+  /*
+   * The CMSIS functions have been implemented as intrinsics in the compiler.
+   * Please use "carm -?i" to get an up to date list of all intrinsics,
+   * Including the CMSIS ones.
+   */
+
+/*------------------ COSMIC Compiler -------------------*/
+#elif defined ( __CSMC__ )
+  #include <cmsis_csm.h>
+
+#endif
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+#endif /* __CORE_CMFUNC_H */

--- a/firmware/S42BV1.0/Close_loop/src/Libraries/cmsis/core_cmInstr.h
+++ b/firmware/S42BV1.0/Close_loop/src/Libraries/cmsis/core_cmInstr.h
@@ -1,0 +1,87 @@
+/**************************************************************************//**
+ * @file     core_cmInstr.h
+ * @brief    CMSIS Cortex-M Core Instruction Access Header File
+ * @version  V4.30
+ * @date     20. October 2015
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2015 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if   defined ( __ICCARM__ )
+ #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CORE_CMINSTR_H
+#define __CORE_CMINSTR_H
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/*------------------ RealView Compiler -----------------*/
+#if   defined ( __CC_ARM )
+  #include "cmsis_armcc.h"
+
+/*------------------ ARM Compiler V6 -------------------*/
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #include "cmsis_armcc_V6.h"
+
+/*------------------ GNU Compiler ----------------------*/
+#elif defined ( __GNUC__ )
+  #include "cmsis_gcc.h"
+
+/*------------------ ICC Compiler ----------------------*/
+#elif defined ( __ICCARM__ )
+  #include <cmsis_iar.h>
+
+/*------------------ TI CCS Compiler -------------------*/
+#elif defined ( __TMS470__ )
+  #include <cmsis_ccs.h>
+
+/*------------------ TASKING Compiler ------------------*/
+#elif defined ( __TASKING__ )
+  /*
+   * The CMSIS functions have been implemented as intrinsics in the compiler.
+   * Please use "carm -?i" to get an up to date list of all intrinsics,
+   * Including the CMSIS ones.
+   */
+
+/*------------------ COSMIC Compiler -------------------*/
+#elif defined ( __CSMC__ )
+  #include <cmsis_csm.h>
+
+#endif
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#endif /* __CORE_CMINSTR_H */

--- a/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
+++ b/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
@@ -14,8 +14,9 @@
         "0x0004"
       ]
     ],
-    "ldscript": "STM32F030C8_FLASH.ld",
+    "ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
     "mcu": "stm32f030c8t6",
+	"product_line": "STM32F030X8",
     "variant": "stm32f0"
   },
   "debug": {

--- a/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
+++ b/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
@@ -16,7 +16,7 @@
     ],
     "ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
     "mcu": "stm32f030c8t6",
-	"product_line": "STM32F030X8",
+    "product_line": "STM32F030X8",
     "variant": "stm32f0"
   },
   "debug": {

--- a/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
+++ b/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
@@ -14,7 +14,7 @@
         "0x0004"
       ]
     ],
-	"ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
+    "ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
     "mcu": "stm32f030c8t6",
 	"product_line": "STM32F030X8",
     "variant": "stm32f0"

--- a/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
+++ b/firmware/S42BV1.0/buildroot/boards/STM32F030C8.json
@@ -14,7 +14,7 @@
         "0x0004"
       ]
     ],
-    "ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
+	"ldscript": "buildroot/ldscripts/STM32F030C8_FLASH.ld",
     "mcu": "stm32f030c8t6",
 	"product_line": "STM32F030X8",
     "variant": "stm32f0"


### PR DESCRIPTION
Since version 10 of https://github.com/platformio/platform-ststm32/, custom board JSON files need to have a `product_line` value with which the startup script is selected. 

Without that, compiling this project gives

```
Processing BIGTREE_S42B_V1_0 (platform: ststm32; framework: stm32cube; board: STM32F030C8)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/ststm32/STM32F030C8.html
PLATFORM: ST STM32 (11.0.0) > STM32F030C8 (8k RAM. 64k Flash)
HARDWARE: STM32F030C8T6 48MHz, 8KB RAM, 64KB Flash
DEBUG: Current (blackmagic) External (blackmagic, cmsis-dap, jlink, stlink)
PACKAGES:
 - framework-stm32cubef0 1.11.1
 - tool-ldscripts-ststm32 0.1.0
 - toolchain-gccarmnoneeabi 1.70201.0 (7.2.1)
AssertionError: Missing MCU or Product Line field:
  File "C:\Users\Max\AppData\Local\Programs\Python\Python38\Lib\site-packages\platformio\builder\main.py", line 170:
    env.SConscript("$BUILD_SCRIPT")
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Script\SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Script\SConscript.py", line 287:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\Users\Max\.platformio\platforms\ststm32\builder\main.py", line 99:
    target_elf = env.BuildProgram()
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Environment.py", line 219:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\AppData\Local\Programs\Python\Python38\Lib\site-packages\platformio\builder\tools\platformio.py", line 61:
    env.ProcessProgramDeps()
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Environment.py", line 219:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\AppData\Local\Programs\Python\Python38\Lib\site-packages\platformio\builder\tools\platformio.py", line 127:
    env.BuildFrameworks(env.get("PIOFRAMEWORK"))
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Environment.py", line 219:
    return self.method(*nargs, **kwargs)
  File "C:\Users\Max\AppData\Local\Programs\Python\Python38\Lib\site-packages\platformio\builder\tools\platformio.py", line 342:
    SConscript(env.GetFrameworkScript(f), exports="env")
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Script\SConscript.py", line 661:
    return method(*args, **kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Script\SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\Users\Max\.platformio\packages\tool-scons\scons-local-4.0.1\SCons\Script\SConscript.py", line 287:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\Users\Max\.platformio\platforms\ststm32\builder\frameworks\stm32cube.py", line 43:
    assert PRODUCT_LINE, "Missing MCU or Product Line field"
========================================================================================== [FAILED] Took 0.76 seconds ==========================================================================================
```

After correcting that, more errors arise during compilation

```

Compiling .pioenvs\BIGTREE_S42B_V1_0\src\src\Libraries\Stm32F0_lib\Src\stm32f0xx_ll_utils.o
Compiling .pioenvs\BIGTREE_S42B_V1_0\src\src\User\main.o
Compiling .pioenvs\BIGTREE_S42B_V1_0\src\src\User\stm32f0xx_it.o
Compiling .pioenvs\BIGTREE_S42B_V1_0\src\src\User\system_stm32f0xx.o
In file included from Close_loop\src\Libraries\cmsis/stm32f030x8.h:125:0,
                 from Close_loop\src\Libraries\cmsis/stm32f0xx.h:135,
                 from Close_loop\src\Libraries\Stm32F0_lib\Inc/stm32f0xx_ll_spi.h:45,
                 from Close_loop\src\Libraries\Stm32F0_lib\Src\stm32f0xx_ll_spi.c:38:
Close_loop\src\Libraries\cmsis/core_cm0.h:163:10: fatal error: core_cmInstr.h: No such file or directory
```

because this project includes its own CMSIS library but there is no `core_cmInstr.h` file. That was added.

Finally, the value of the ldscript path is corrected.

Please note that `iap.py` is still wrong, it does a `env.Replace(LDSCRIPT_PATH="buildroot/ldscripts/BIGTREE_S42B_V1.ld")` and that file doesn't exist anywhere in this repo. But since that `extra_scripts` directive is commented out, it is not used anyways.

You should be able to reproduce the errors if you update your PlatformIO core (`pio upgrade --dev`) and platforms (`pio platforms update`) in the [CLI](https://docs.platformio.org/en/latest/integration/ide/vscode.html#platformio-core-cli).

Another way of fixing would be of course to correct the line 

```
platform = ststm32
```
to include the exact version with which it compiled, e.g. `ststm32@9.0.0`. Since I don't know which versions you used, I fixed it by updating. 

**Note that I only tested that the firmware compiled, not that it runs.** Someone else would have to verify that, since I don't have the hardware.